### PR TITLE
Relaxed esbuild dependency

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "esbuild-copy",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.0",
+      "name": "esbuild-copy",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "tiny-glob": "^0.2.9"
@@ -15,7 +16,7 @@
         "typescript": "^4.5.2"
       },
       "peerDependencies": {
-        "esbuild": "^0.14.1"
+        "esbuild": "*"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "description": "",
-  "keywords": [
-  ],
+  "keywords": [],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +20,7 @@
     "tiny-glob": "^0.2.9"
   },
   "peerDependencies": {
-    "esbuild": "^0.14.1"
+    "esbuild": "*"
   },
   "devDependencies": {
     "@types/node": "^16.11.11",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,18 @@
 {
-    "extends": "../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist"
-    }
+  "compilerOptions": {
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "target": "es5",
+    "module": "es2015",
+    "lib": ["es2015", "es2016", "es2017", "dom"],
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "typeRoots": ["node_modules/@types"]
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Hi @bognarlaszlo, thank you for a wonderful plugin with a nice and simple API.

This PR does the following:
 - relaxes dependency on `esbuild@0.14.x` to `*`
 - filled up `tsconfig.json`, since it wasn't included in the project, so local build would not have work